### PR TITLE
Move `data` to `api`

### DIFF
--- a/pyairvisual/api.py
+++ b/pyairvisual/api.py
@@ -2,7 +2,7 @@
 from typing import Awaitable, Callable, Union
 
 
-class Data:
+class API:
     """Define the "Data" endpoint group."""
 
     def __init__(self, request: Callable[..., Awaitable[dict]]) -> None:

--- a/pyairvisual/client.py
+++ b/pyairvisual/client.py
@@ -1,7 +1,7 @@
 """Define a client to interact with AirVisual."""
 import aiohttp
 
-from .data import Data
+from .api import API
 from .errors import raise_error
 from .supported import Supported
 
@@ -17,7 +17,7 @@ class Client:  # pylint: disable=too-few-public-methods
         self._api_key = api_key
         self.websession = websession
 
-        self.data = Data(self.request)
+        self.api = API(self.request)
         self.supported = Supported(self.request)
 
     async def request(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -252,20 +252,20 @@ async def test_endpoints(
     async with aiohttp.ClientSession(loop=event_loop) as websession:
         client = Client(TEST_API_KEY, websession)
 
-        data = await client.data.nearest_city(
+        data = await client.api.nearest_city(
             latitude=TEST_LATITUDE, longitude=TEST_LONGITUDE)
         assert data['city'] == 'Los Angeles'
 
-        data = await client.data.city(TEST_CITY, TEST_STATE, TEST_COUNTRY)
+        data = await client.api.city(TEST_CITY, TEST_STATE, TEST_COUNTRY)
         assert data['city'] == 'Los Angeles'
 
-        data = await client.data.nearest_station(
+        data = await client.api.nearest_station(
             latitude=TEST_LATITUDE, longitude=TEST_LONGITUDE)
         assert data['name'] == 'US Embassy in Beijing'
 
-        data = await client.data.station(
+        data = await client.api.station(
             TEST_STATION_NAME, TEST_CITY, TEST_STATE, TEST_COUNTRY)
         assert data['name'] == 'US Embassy in Beijing'
 
-        data = await client.data.ranking()
+        data = await client.api.ranking()
         assert len(data) == 3

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -34,7 +34,7 @@ async def test_api_key_expired(aresponses, event_loop, fixture_key_expired):
     with pytest.raises(KeyExpiredError):
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             client = Client(TEST_API_KEY, websession)
-            await client.data.nearest_city()
+            await client.api.nearest_city()
 
 
 @pytest.mark.asyncio
@@ -48,4 +48,4 @@ async def test_generic_error(aresponses, event_loop, fixture_generic_error):
     with pytest.raises(AirVisualError):
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             client = Client(TEST_API_KEY, websession)
-            await client.data.nearest_city()
+            await client.api.nearest_city()


### PR DESCRIPTION
**Describe what the PR does:**

This PR moves all of the `data` operations to a new API endpoint: `api`

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
