### PR TITLE
Adjust version pinning to fix Travis

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,14 +5,16 @@ verify_ssl = true
 [dev-packages]
 "flake8" = "*"
 aresponses = "*"
+astroid = "<2.2.0"
 detox = "*"
 mypy = "*"
 pydocstyle = "*"
-pylint = "*"
+pylint = "<2.3.0"
 pytest-aiohttp = "*"
 pytest-cov = "*"
 tox = "*"
 twine = "*"
+typed-ast = "<1.4.0,>=1.3.1"
 
 [packages]
 aiohttp = "*"


### PR DESCRIPTION
**Describe what the PR does:**

`pipenv`'s dependency resolver is struggling with various combinations of `astroid`, `pylint`, `typed-ast` (documented [here](https://github.com/pypa/pipenv/issues/3568) and [here](https://github.com/PyCQA/astroid/issues/639)). This PR pins some dependencies to get things working until `pipenv` comes up with a better solution.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)