### PR TITLE
Add Python 3.6-style variable type annotations

### DIFF
--- a/pyairvisual/api.py
+++ b/pyairvisual/api.py
@@ -1,5 +1,5 @@
 """Define an object to interact with the AirVisual data API."""
-from typing import Awaitable, Callable, Union
+from typing import Awaitable, Callable, Optional, Union
 
 from .const import NODE_URL_SCAFFOLD
 
@@ -9,37 +9,41 @@ class API:
 
     def __init__(self, request: Callable[..., Awaitable[dict]]) -> None:
         """Iniitialize."""
-        self._request = request
+        self._request: Callable[..., Awaitable[dict]] = request
 
     async def _nearest(
         self,
         kind: str,
-        latitude: Union[float, str] = None,
-        longitude: Union[float, str] = None,
+        latitude: Optional[Union[float, str]] = None,
+        longitude: Optional[Union[float, str]] = None,
     ) -> dict:
         """Return data from nearest city/station (IP or coordinates)."""
-        params = {}
+        params: dict = {}
         if latitude and longitude:
             params.update({"lat": str(latitude), "lon": str(longitude)})
 
-        data = await self._request("get", f"nearest_{kind}", params=params)
+        data: dict = await self._request("get", f"nearest_{kind}", params=params)
         return data["data"]
 
     async def city(self, city: str, state: str, country: str) -> dict:
         """Return data for the specified city."""
-        data = await self._request(
+        data: dict = await self._request(
             "get", "city", params={"city": city, "state": state, "country": country}
         )
         return data["data"]
 
     async def nearest_city(
-        self, latitude: Union[float, str] = None, longitude: Union[float, str] = None
+        self,
+        latitude: Optional[Union[float, str]] = None,
+        longitude: Optional[Union[float, str]] = None,
     ) -> dict:
         """Return data from nearest city (IP or coordinates)."""
         return await self._nearest("city", latitude, longitude)
 
     async def nearest_station(
-        self, latitude: Union[float, str] = None, longitude: Union[float, str] = None
+        self,
+        latitude: Optional[Union[float, str]] = None,
+        longitude: Optional[Union[float, str]] = None,
     ) -> dict:
         """Return data from nearest station (IP or coordinates)."""
         return await self._nearest("station", latitude, longitude)
@@ -55,7 +59,7 @@ class API:
 
     async def station(self, station: str, city: str, state: str, country: str) -> dict:
         """Return data for the specified city."""
-        data = await self._request(
+        data: dict = await self._request(
             "get",
             "station",
             params={

--- a/pyairvisual/client.py
+++ b/pyairvisual/client.py
@@ -1,5 +1,5 @@
 """Define a client to interact with AirVisual."""
-from typing import Union
+from typing import Optional, Union
 
 import aiohttp
 
@@ -13,14 +13,14 @@ class Client:  # pylint: disable=too-few-public-methods
     """Define the client."""
 
     def __init__(
-        self, websession: aiohttp.ClientSession, *, api_key: str = None
+        self, websession: aiohttp.ClientSession, *, api_key: Optional[str] = None
     ) -> None:
         """Initialize."""
-        self._api_key = api_key
-        self.websession = websession
+        self._api_key: Optional[str] = api_key
+        self.websession: aiohttp.ClientSession = websession
 
-        self.api = API(self.request)
-        self.supported = Supported(self.request)
+        self.api: API = API(self.request)
+        self.supported: Supported = Supported(self.request)
 
     async def request(
         self,
@@ -28,9 +28,9 @@ class Client:  # pylint: disable=too-few-public-methods
         endpoint: str,
         *,
         base_url: str = API_URL_SCAFFOLD,
-        headers: dict = None,
-        params: dict = None,
-        json: dict = None,
+        headers: Optional[dict] = None,
+        params: Optional[dict] = None,
+        json: Optional[dict] = None,
     ) -> dict:
         """Make a request against AirVisual."""
         if not headers:
@@ -43,13 +43,12 @@ class Client:  # pylint: disable=too-few-public-methods
         if self._api_key:
             params.update({"key": self._api_key})
 
-        url = f"{base_url}/{endpoint}"
         async with self.websession.request(
-            method, url, headers=headers, params=params, json=json
+            method, f"{base_url}/{endpoint}", headers=headers, params=params, json=json
         ) as resp:
-            data = await resp.json(content_type=None)
+            data: Union[str, dict] = await resp.json(content_type=None)
             _raise_on_error(data)
-            return data
+            return data  # type: ignore
 
 
 def _raise_on_error(data: Union[str, dict]) -> None:

--- a/pyairvisual/errors.py
+++ b/pyairvisual/errors.py
@@ -1,4 +1,5 @@
 """Define package errors."""
+from typing import Dict, Type
 
 
 class AirVisualError(Exception):
@@ -49,7 +50,7 @@ class UnauthorizedError(AirVisualError):
     pass
 
 
-ERROR_CODES = {
+ERROR_CODES: Dict[str, Type[AirVisualError]] = {
     "api_key_expired": KeyExpiredError,
     "call_limit_reached": LimitReachedError,
     "city_not_found": NotFoundError,
@@ -62,6 +63,7 @@ ERROR_CODES = {
 
 def raise_error(error_type: str) -> None:
     """Raise the appropriate error based on error message."""
+    error: Type[AirVisualError]
     try:
         error = next((v for k, v in ERROR_CODES.items() if k in error_type))
     except StopIteration:

--- a/pyairvisual/supported.py
+++ b/pyairvisual/supported.py
@@ -7,28 +7,28 @@ class Supported:
 
     def __init__(self, request: Callable[..., Awaitable[dict]]) -> None:
         """Iniitialize."""
-        self._request = request
+        self._request: Callable[..., Awaitable[dict]] = request
 
     async def cities(self, country: str, state: str) -> list:
         """Return a list of supported cities in a country/state."""
-        data = await self._request(
+        data: dict = await self._request(
             "get", "cities", params={"state": state, "country": country}
         )
         return [d["city"] for d in data["data"]]
 
     async def countries(self) -> list:
         """Return an array of all supported countries."""
-        data = await self._request("get", "countries")
+        data: dict = await self._request("get", "countries")
         return [d["country"] for d in data["data"]]
 
     async def states(self, country: str) -> list:
         """Return a list of supported states in a country."""
-        data = await self._request("get", "states", params={"country": country})
+        data: dict = await self._request("get", "states", params={"country": country})
         return [d["state"] for d in data["data"]]
 
     async def stations(self, city: str, state: str, country: str) -> list:
         """Return a list of supported stations in a city."""
-        data = await self._request(
+        data: dict = await self._request(
             "get", "stations", params={"city": city, "state": state, "country": country}
         )
         return data["data"]


### PR DESCRIPTION
**Describe what the PR does:**

Now that we can ensure a minimum of Python 3.6, we can use Python 3.6-style type annotations for variables.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
