### PR TITLE
Officially support Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,7 @@ matrix:
       env: TOXENV=py37
       dist: xenial
       sudo: true
-    - python: "3.8-dev"
-      env: TOXENV=py38
-      dist: xenial
-      sudo: true
-      if: branch = dev AND type = push
-  allow_failures:
-    - python: "3.8-dev"
+    - python: "3.8"
       env: TOXENV=py38
       dist: xenial
       sudo: true

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ If you wish to continue using the previous, synchronous version of
 
 * Python 3.6
 * Python 3.7
+* Python 3.8
 
 # Installation
 

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],


### PR DESCRIPTION
**Describe what the PR does:**

Since Python 3.8 is now in the wild, this adds CI and documentation on supporting it.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
