### PR TITLE
Fix bug with "JSON" response that is actually a quoted string

### DIFF
--- a/pyairvisual/errors.py
+++ b/pyairvisual/errors.py
@@ -63,7 +63,6 @@ ERROR_CODES: Dict[str, Type[AirVisualError]] = {
 
 def raise_error(error_type: str) -> None:
     """Raise the appropriate error based on error message."""
-    error: Type[AirVisualError]
     try:
         error = next((v for k, v in ERROR_CODES.items() if k in error_type))
     except StopIteration:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,7 +24,9 @@ async def test_aqi_ranking(aresponses):
         "/v2/city_ranking",
         "get",
         aresponses.Response(
-            text=load_fixture("city_ranking_response.json"), status=200
+            text=load_fixture("city_ranking_response.json"),
+            headers={"Content-Type": "application/json"},
+            status=200,
         ),
     )
 
@@ -44,7 +46,11 @@ async def test_city_by_coordinates(aresponses):
         "api.airvisual.com",
         "/v2/nearest_city",
         "get",
-        aresponses.Response(text=load_fixture("city_response.json"), status=200),
+        aresponses.Response(
+            text=load_fixture("city_response.json"),
+            headers={"Content-Type": "application/json"},
+            status=200,
+        ),
     )
 
     async with aiohttp.ClientSession() as websession:
@@ -64,7 +70,11 @@ async def test_city_by_ip(aresponses):
         "api.airvisual.com",
         "/v2/nearest_city",
         "get",
-        aresponses.Response(text=load_fixture("city_response.json"), status=200),
+        aresponses.Response(
+            text=load_fixture("city_response.json"),
+            headers={"Content-Type": "application/json"},
+            status=200,
+        ),
     )
 
     async with aiohttp.ClientSession() as websession:
@@ -82,7 +92,11 @@ async def test_city_by_name(aresponses):
         "api.airvisual.com",
         "/v2/city",
         "get",
-        aresponses.Response(text=load_fixture("city_response.json"), status=200),
+        aresponses.Response(
+            text=load_fixture("city_response.json"),
+            headers={"Content-Type": "application/json"},
+            status=200,
+        ),
     )
 
     async with aiohttp.ClientSession() as websession:
@@ -103,7 +117,11 @@ async def test_node(aresponses):
         "www.airvisual.com",
         "/api/v2/node/12345",
         "get",
-        aresponses.Response(text=load_fixture("node_response.json"), status=200),
+        aresponses.Response(
+            text=load_fixture("node_response.json"),
+            headers={"Content-Type": "application/json"},
+            status=200,
+        ),
     )
 
     async with aiohttp.ClientSession() as websession:
@@ -122,7 +140,11 @@ async def test_station_by_coordinates(aresponses):
         "api.airvisual.com",
         "/v2/nearest_station",
         "get",
-        aresponses.Response(text=load_fixture("station_response.json"), status=200),
+        aresponses.Response(
+            text=load_fixture("station_response.json"),
+            headers={"Content-Type": "application/json"},
+            status=200,
+        ),
     )
 
     async with aiohttp.ClientSession() as websession:
@@ -142,7 +164,11 @@ async def test_station_by_ip(aresponses):
         "api.airvisual.com",
         "/v2/nearest_station",
         "get",
-        aresponses.Response(text=load_fixture("station_response.json"), status=200),
+        aresponses.Response(
+            text=load_fixture("station_response.json"),
+            headers={"Content-Type": "application/json"},
+            status=200,
+        ),
     )
 
     async with aiohttp.ClientSession() as websession:
@@ -160,7 +186,11 @@ async def test_station_by_name(aresponses):
         "api.airvisual.com",
         "/v2/station",
         "get",
-        aresponses.Response(text=load_fixture("station_response.json"), status=200),
+        aresponses.Response(
+            text=load_fixture("station_response.json"),
+            headers={"Content-Type": "application/json"},
+            status=200,
+        ),
     )
 
     async with aiohttp.ClientSession() as websession:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -24,7 +24,9 @@ async def test_api_key_expired(aresponses):
         "/v2/nearest_city",
         "get",
         aresponses.Response(
-            text=load_fixture("error_key_expired_response.json"), status=401
+            text=load_fixture("error_key_expired_response.json"),
+            headers={"Content-Type": "application/json"},
+            status=401,
         ),
     )
 
@@ -42,7 +44,9 @@ async def test_call_limit_reached(aresponses):
         "/v2/nearest_city",
         "get",
         aresponses.Response(
-            text=load_fixture("error_limit_reached_response.json"), status=401
+            text=load_fixture("error_limit_reached_response.json"),
+            headers={"Content-Type": "application/json"},
+            status=401,
         ),
     )
 
@@ -60,7 +64,9 @@ async def test_city_not_found(aresponses):
         "/v2/nearest_city",
         "get",
         aresponses.Response(
-            text=load_fixture("error_city_not_found_response.json"), status=401
+            text=load_fixture("error_city_not_found_response.json"),
+            headers={"Content-Type": "application/json"},
+            status=401,
         ),
     )
 
@@ -78,7 +84,9 @@ async def test_generic_error(aresponses):
         "/v2/nearest_city",
         "get",
         aresponses.Response(
-            text=load_fixture("error_generic_response.json"), status=401
+            text=load_fixture("error_generic_response.json"),
+            headers={"Content-Type": "application/json"},
+            status=401,
         ),
     )
 
@@ -96,7 +104,9 @@ async def test_incorrect_api_key(aresponses):
         "/v2/nearest_city",
         "get",
         aresponses.Response(
-            text=load_fixture("error_incorrect_api_key_response.json"), status=401
+            text=load_fixture("error_incorrect_api_key_response.json"),
+            headers={"Content-Type": "application/json"},
+            status=401,
         ),
     )
 
@@ -114,7 +124,9 @@ async def test_no_nearest_station(aresponses):
         "/v2/nearest_station",
         "get",
         aresponses.Response(
-            text=load_fixture("error_no_nearest_station_response.json"), status=401
+            text=load_fixture("error_no_nearest_station_response.json"),
+            headers={"Content-Type": "application/json"},
+            status=401,
         ),
     )
 
@@ -125,18 +137,42 @@ async def test_no_nearest_station(aresponses):
 
 
 @pytest.mark.asyncio
-async def test_node_not_found(aresponses, event_loop):
+async def test_node_not_found(aresponses):
     """Test that the proper error is raised when no Pro node is found."""
     aresponses.add(
         "www.airvisual.com",
         "/api/v2/node/12345",
         "get",
-        aresponses.Response(text="node not found", status=200),
+        aresponses.Response(
+            text='"node not found"',
+            headers={"Content-Type": "application/json"},
+            status=200,
+        ),
     )
 
     with pytest.raises(NotFoundError):
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            client = Client(websession, api_key=TEST_API_KEY)
+        async with aiohttp.ClientSession() as websession:
+            client = Client(websession)
+            await client.api.node("12345")
+
+
+@pytest.mark.asyncio
+async def test_non_json_response(aresponses):
+    """Test that the proper error is raised when the response text isn't JSON."""
+    aresponses.add(
+        "www.airvisual.com",
+        "/api/v2/node/12345",
+        "get",
+        aresponses.Response(
+            text="This is a valid response, but it isn't JSON.",
+            headers={"Content-Type": "application/json"},
+            status=200,
+        ),
+    )
+
+    with pytest.raises(AirVisualError):
+        async with aiohttp.ClientSession() as websession:
+            client = Client(websession)
             await client.api.node("12345")
 
 
@@ -148,7 +184,9 @@ async def test_permission_denied(aresponses):
         "/v2/nearest_station",
         "get",
         aresponses.Response(
-            text=load_fixture("error_permission_denied_response.json"), status=401
+            text=load_fixture("error_permission_denied_response.json"),
+            headers={"Content-Type": "application/json"},
+            status=401,
         ),
     )
 

--- a/tests/test_supported.py
+++ b/tests/test_supported.py
@@ -14,7 +14,11 @@ async def test_cities(aresponses):
         "api.airvisual.com",
         "/v2/cities",
         "get",
-        aresponses.Response(text=load_fixture("cities_response.json"), status=200),
+        aresponses.Response(
+            text=load_fixture("cities_response.json"),
+            headers={"Content-Type": "application/json"},
+            status=200,
+        ),
     )
 
     async with aiohttp.ClientSession() as websession:
@@ -30,7 +34,11 @@ async def test_countries(aresponses):
         "api.airvisual.com",
         "/v2/countries",
         "get",
-        aresponses.Response(text=load_fixture("countries_response.json"), status=200),
+        aresponses.Response(
+            text=load_fixture("countries_response.json"),
+            headers={"Content-Type": "application/json"},
+            status=200,
+        ),
     )
 
     async with aiohttp.ClientSession() as websession:
@@ -46,7 +54,11 @@ async def test_states(aresponses):
         "api.airvisual.com",
         "/v2/states",
         "get",
-        aresponses.Response(text=load_fixture("states_response.json"), status=200),
+        aresponses.Response(
+            text=load_fixture("states_response.json"),
+            headers={"Content-Type": "application/json"},
+            status=200,
+        ),
     )
 
     async with aiohttp.ClientSession() as websession:
@@ -62,7 +74,11 @@ async def test_stations(aresponses):
         "api.airvisual.com",
         "/v2/stations",
         "get",
-        aresponses.Response(text=load_fixture("stations_response.json"), status=200),
+        aresponses.Response(
+            text=load_fixture("stations_response.json"),
+            headers={"Content-Type": "application/json"},
+            status=200,
+        ),
     )
 
     async with aiohttp.ClientSession() as websession:


### PR DESCRIPTION
**Describe what the PR does:**

I recently noticed that invalid Node/Pro IDs weren't raising the correct exception – in fact, they weren't raising an exception at all (even though we had one defined for this case). The problem lies within the response text:

```txt
HTTP/1.1 200 OK
Content-Type: application/json
Transfer-Encoding: chunked
Connection: close
Date: Wed, 11 Mar 2020 03:41:01 GMT

"node not found"
```

My eyes skipped right over it, but that response contains a quoted string – if I were to assign this value to a variable, I would have to do this:

```python
s = '"node not found"'
```

Fascinatingly, a quoted string is _technically_ valid JSON (in that Python's `json` module parses it as JSON). Combined with the fact that, bewilderingly, the response's `Content-Type` header is set to `application/json`, this response was viewed by the library as valid. Wild!

This PR rectifies the issue and now properly checks for this kind of scenario.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
