### PR TITLE
Move Node/Pro endpoints to their own object

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ async def main() -> None:
     async with ClientSession() as websession:
     # If an API key isn't provided, only Nodes can be queried; everything else
     # requires an API key:
-    client = Client(websession, api_key='<YOUR AIRVISUAL API KEY>')
+    client = Client(websession, api_key="<YOUR_AIRVISUAL_API_KEY>")
 
     # Get data based on the city nearest to your IP address:
     data = await client.data.nearest_city()
@@ -118,7 +118,7 @@ async def main() -> None:
 
     # ...or get it explicitly:
     data = await client.data.city(
-        city='Los Angeles', state='California', country='USA')
+        city="Los Angeles", state="California", country="USA")
 
     # If you have the appropriate API key, you can also get data based on
     # station (nearest or explicit):
@@ -126,22 +126,22 @@ async def main() -> None:
     data = await client.data.nearest_station(
         latitude=39.742599, longitude=-104.9942557)
     data = await client.data.station(
-        station='US Embassy in Beijing',
-        city='Beijing',
-        state='Beijing',
-        country='China')
+        station="US Embassy in Beijing",
+        city="Beijing",
+        state="Beijing",
+        country="China")
 
     # With the appropriate API key, you can get an air quality ranking:
     data = await client.data.ranking()
 
     # pyairvisual gives you several methods to look locations up:
     countries = await client.supported.countries()
-    states = await client.supported.states('USA')
-    cities = await client.supported.cities('USA', 'Colorado')
-    stations = await client.supported.stations('USA', 'Colorado', 'Denver')
+    states = await client.supported.states("USA")
+    cities = await client.supported.cities("USA", "Colorado")
+    stations = await client.supported.stations("USA", "Colorado", "Denver")
 
-    # AirVisual Nodes can also be queried by ID
-    data = await client.api.node('12345abcdef')
+    # AirVisual Node/Pro units can be queried via the cloud API:
+    data = await client.node.from_cloud_api("12345abcdef")
 
 
 asyncio.get_event_loop().run_until_complete(main())

--- a/examples/test_cloud_api.py
+++ b/examples/test_cloud_api.py
@@ -1,4 +1,4 @@
-"""Run an example script to quickly test."""
+"""Run an example against the AirVisual cloud API."""
 import asyncio
 import logging
 
@@ -12,7 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 API_KEY = "<API_KEY>"
 
 
-async def main() -> None:  # pylint: disable=too-many-statements
+async def main() -> None:
     """Create the aiohttp session and run the example."""
     logging.basicConfig(level=logging.INFO)
     async with ClientSession() as websession:
@@ -90,9 +90,6 @@ async def main() -> None:  # pylint: disable=too-many-statements
             _LOGGER.error(err)
         except AirVisualError as err:
             _LOGGER.error("There was an error: %s", err)
-
-        # Get info on a AirVisual Pro node:
-        _LOGGER.info(await client.api.node("zEp8CifbnasWtToBc"))
 
 
 asyncio.get_event_loop().run_until_complete(main())

--- a/examples/test_node_pro.py
+++ b/examples/test_node_pro.py
@@ -1,0 +1,26 @@
+"""Run an example against an AirVisual Node/Pro."""
+import asyncio
+import logging
+
+from aiohttp import ClientSession
+
+from pyairvisual import Client
+from pyairvisual.errors import AirVisualError
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def main() -> None:
+    """Create the aiohttp session and run the example."""
+    logging.basicConfig(level=logging.INFO)
+    async with ClientSession() as websession:
+        client = Client(websession)
+
+        # Get data from the cloud API:
+        try:
+            _LOGGER.info(await client.node.from_cloud_api("L7L2Yz4kvEHNx3NFT"))
+        except AirVisualError as err:
+            _LOGGER.error("There was an error: %s", err)
+
+
+asyncio.get_event_loop().run_until_complete(main())

--- a/pyairvisual/api.py
+++ b/pyairvisual/api.py
@@ -1,7 +1,7 @@
 """Define an object to interact with the AirVisual data API."""
 from typing import Awaitable, Callable, Optional, Union
 
-from .const import NODE_URL_SCAFFOLD
+API_URL_SCAFFOLD = "https://api.airvisual.com/v2"
 
 
 class API:
@@ -47,10 +47,6 @@ class API:
     ) -> dict:
         """Return data from nearest station (IP or coordinates)."""
         return await self._nearest("station", latitude, longitude)
-
-    async def node(self, node_id: str) -> dict:
-        """Return data from a node by its ID."""
-        return await self._request("get", node_id, base_url=NODE_URL_SCAFFOLD)
 
     async def ranking(self) -> dict:
         """Return a sorted array of selected major cities in the world."""

--- a/pyairvisual/client.py
+++ b/pyairvisual/client.py
@@ -4,9 +4,9 @@ from typing import Optional
 
 import aiohttp
 
-from .api import API
-from .const import API_URL_SCAFFOLD
+from .api import API, API_URL_SCAFFOLD
 from .errors import raise_error
+from .node import Node
 from .supported import Supported
 
 
@@ -21,6 +21,7 @@ class Client:  # pylint: disable=too-few-public-methods
         self.websession: aiohttp.ClientSession = websession
 
         self.api: API = API(self.request)
+        self.node: Node = Node(self.request)
         self.supported: Supported = Supported(self.request)
 
     async def request(

--- a/pyairvisual/const.py
+++ b/pyairvisual/const.py
@@ -1,3 +1,0 @@
-"""Define package constants."""
-API_URL_SCAFFOLD = "https://api.airvisual.com/v2"
-NODE_URL_SCAFFOLD = "https://www.airvisual.com/api/v2/node"

--- a/pyairvisual/errors.py
+++ b/pyairvisual/errors.py
@@ -32,6 +32,12 @@ class NoStationError(AirVisualError):
     pass
 
 
+class NodeProError(AirVisualError):
+    """Define an error related to Node/Pro errors."""
+
+    pass
+
+
 class NotFoundError(AirVisualError):
     """Define an error for when a location (city or node) cannot be found."""
 
@@ -56,13 +62,14 @@ ERROR_CODES: Dict[str, Type[AirVisualError]] = {
     "city_not_found": NotFoundError,
     "incorrect_api_key": InvalidKeyError,
     "no_nearest_station": NoStationError,
-    "node not found": NotFoundError,
+    "node not found": NodeProError,
     "permission_denied": UnauthorizedError,
 }
 
 
 def raise_error(error_type: str) -> None:
     """Raise the appropriate error based on error message."""
+    error: Type[AirVisualError]
     try:
         error = next((v for k, v in ERROR_CODES.items() if k in error_type))
     except StopIteration:

--- a/pyairvisual/node.py
+++ b/pyairvisual/node.py
@@ -1,0 +1,19 @@
+"""Define an object to interact with an AirVisual Node/Pro."""
+import logging
+from typing import Awaitable, Callable
+
+NODE_URL_SCAFFOLD = "https://www.airvisual.com/api/v2/node"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Node:  # pylint: disable=too-few-public-methods
+    """Define the "API" object."""
+
+    def __init__(self, request: Callable[..., Awaitable[dict]]) -> None:
+        """Iniitialize."""
+        self._request: Callable[..., Awaitable[dict]] = request
+
+    async def from_cloud_api(self, node_id: str) -> dict:
+        """Return cloud API data from a node its ID."""
+        return await self._request("get", node_id, base_url=NODE_URL_SCAFFOLD)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
 [tool.poetry.dependencies]
 aiohttp = "^3.6.2"
 python = "^3.6.0"
+pysmb = "^1.1.28"
 
 [tool.poetry.dev-dependencies]
 aresponses = "^1.1.1"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -111,29 +111,6 @@ async def test_city_by_name(aresponses):
 
 
 @pytest.mark.asyncio
-async def test_node(aresponses):
-    """Test getting a node."""
-    aresponses.add(
-        "www.airvisual.com",
-        "/api/v2/node/12345",
-        "get",
-        aresponses.Response(
-            text=load_fixture("node_response.json"),
-            headers={"Content-Type": "application/json"},
-            status=200,
-        ),
-    )
-
-    async with aiohttp.ClientSession() as websession:
-        client = Client(websession, api_key=TEST_API_KEY)
-        data = await client.api.node("12345")
-        assert data["current"]["tp"] == 2.3
-        assert data["current"]["hm"] == 73
-        assert data["current"]["p2"] == 35
-        assert data["current"]["co"] == 479
-
-
-@pytest.mark.asyncio
 async def test_station_by_coordinates(aresponses):
     """Test getting a station by latitude and longitude."""
     aresponses.add(

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -8,6 +8,7 @@ from pyairvisual.errors import (
     InvalidKeyError,
     KeyExpiredError,
     LimitReachedError,
+    NodeProError,
     NoStationError,
     NotFoundError,
     UnauthorizedError,
@@ -150,10 +151,10 @@ async def test_node_not_found(aresponses):
         ),
     )
 
-    with pytest.raises(NotFoundError):
+    with pytest.raises(NodeProError):
         async with aiohttp.ClientSession() as websession:
             client = Client(websession)
-            await client.api.node("12345")
+            await client.node.from_cloud_api("12345")
 
 
 @pytest.mark.asyncio
@@ -173,7 +174,7 @@ async def test_non_json_response(aresponses):
     with pytest.raises(AirVisualError):
         async with aiohttp.ClientSession() as websession:
             client = Client(websession)
-            await client.api.node("12345")
+            await client.node.from_cloud_api("12345")
 
 
 @pytest.mark.asyncio

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,0 +1,30 @@
+"""Define tests for the "Node" object."""
+import aiohttp
+import pytest
+
+from pyairvisual import Client
+
+from .common import TEST_API_KEY, load_fixture
+
+
+@pytest.mark.asyncio
+async def test_node(aresponses):
+    """Test getting a node."""
+    aresponses.add(
+        "www.airvisual.com",
+        "/api/v2/node/12345",
+        "get",
+        aresponses.Response(
+            text=load_fixture("node_response.json"),
+            headers={"Content-Type": "application/json"},
+            status=200,
+        ),
+    )
+
+    async with aiohttp.ClientSession() as websession:
+        client = Client(websession, api_key=TEST_API_KEY)
+        data = await client.node.from_cloud_api("12345")
+        assert data["current"]["tp"] == 2.3
+        assert data["current"]["hm"] == 73
+        assert data["current"]["p2"] == 35
+        assert data["current"]["co"] == 479


### PR DESCRIPTION
**Describe what the PR does:**

I'm discovering more Node/Pro functionality, so it makes sense to move the current endpoint out of `API` and into its own object.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
