### PR TITLE
Allow Release Drafter to understand "Maintenance" label

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -10,6 +10,7 @@ categories:
     labels:
       - "ci/cd"
       - "dependencies"
+      - "maintenance"
       - "tooling"
 change-template: "- $TITLE (#$NUMBER)"
 name-template: "$NEXT_PATCH_VERSION"


### PR DESCRIPTION
**Describe what the PR does:**

This PR ensures that the Release Drafter action understands `Maintenance` labels.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
