### PR TITLE
Don't calculate trend range for every metric

### DIFF
--- a/pyairvisual/node.py
+++ b/pyairvisual/node.py
@@ -70,6 +70,7 @@ TREND_DECREASING = "decreasing"
 def _calculate_trends(history: List[OrderedDict]) -> dict:
     """Calculate the trends of all data points in history data."""
     trends = {}
+    index_range = np.arange(0, len(history))
 
     for attribute in METRICS_TO_TREND:
         values = [
@@ -79,7 +80,6 @@ def _calculate_trends(history: List[OrderedDict]) -> dict:
             if attr == attribute
         ]
 
-        index_range = np.arange(0, len(values))
         index_array = np.array(values)
         linear_fit = np.polyfit(index_range, index_array, 1,)
         slope = round(linear_fit[0], 2)


### PR DESCRIPTION
**Describe what the PR does:**

When calculating Node/Pro trends, we were calculating the data range with each metric being measured, which was wasteful and unnecessary. This PR cleans that up.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
