### PR TITLE
History data points

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ async def main() -> None:
 asyncio.get_event_loop().run_until_complete(main())
 ```
 
-...or over the local network:
+...or over the local network (the unit password can be found on the device itself):
 
 ```python
 import asyncio
@@ -188,12 +188,17 @@ async def main() -> None:
     async with ClientSession() as websession:
         client = Client(websession)
 
-        # The unit password can be found on the device itself:
+        # Can take several optional parameters:
+        #   1. include_history: include historical measurements (defaults to True)
+        #   2. include_trends: include trends (defaults to True)
+        #   3. measurements_to_use: the number of measurements to use when calculating
+        #      trends (defaults to -1, which means "use all measurements")
         data = await client.node.from_samba(
             "<IP_ADDRESS_OR_HOST>",
             "<PASSWORD>",
             include_history=True,
             include_trends=True,
+            measurements_to_use=10,
         )
 
 

--- a/examples/test_node_pro.py
+++ b/examples/test_node_pro.py
@@ -11,8 +11,8 @@ _LOGGER = logging.getLogger(__name__)
 
 NODE_PRO_ID = "<NODE_PRO_ID>"
 
-NODE_PRO_IP_ADDRESS = "<NODE_PRO_IP_ADDRESS>"
-NODE_PRO_PASSWORD = "<NODE_PRO_PASSWORD>"
+NODE_PRO_IP_ADDRESS = "172.16.11.180"
+NODE_PRO_PASSWORD = "j9h46kar"
 
 
 async def main() -> None:
@@ -22,15 +22,19 @@ async def main() -> None:
         client = Client(websession)
 
         # Get data from the cloud API:
-        try:
-            _LOGGER.info(await client.node.from_cloud_api(NODE_PRO_ID))
-        except AirVisualError as err:
-            _LOGGER.error("There was an error: %s", err)
+        # try:
+        #     _LOGGER.info(await client.node.from_cloud_api(NODE_PRO_ID))
+        # except AirVisualError as err:
+        #     _LOGGER.error("There was an error: %s", err)
 
         # Get data from the local Samba share on the unit:
         try:
             _LOGGER.info(
-                await client.node.from_samba(NODE_PRO_IP_ADDRESS, NODE_PRO_PASSWORD)
+                await client.node.from_samba(
+                    NODE_PRO_IP_ADDRESS,
+                    NODE_PRO_PASSWORD,
+                    include_trends=False,
+                ),
             )
         except AirVisualError as err:
             _LOGGER.error("There was an error: %s", err)

--- a/pyairvisual/node.py
+++ b/pyairvisual/node.py
@@ -67,10 +67,14 @@ TREND_INCREASING = "increasing"
 TREND_DECREASING = "decreasing"
 
 
-def _calculate_trends(history: List[OrderedDict]) -> dict:
+def _calculate_trends(history: List[OrderedDict], measurements_to_use: int) -> dict:
     """Calculate the trends of all data points in history data."""
     trends = {}
-    index_range = np.arange(0, len(history))
+
+    if measurements_to_use == -1:
+        index_range = np.arange(0, len(history))
+    else:
+        index_range = np.arange(0, measurements_to_use)
 
     for attribute in METRICS_TO_TREND:
         values = [
@@ -79,6 +83,9 @@ def _calculate_trends(history: List[OrderedDict]) -> dict:
             for attr, value in measurement.items()
             if attr == attribute
         ]
+
+        if measurements_to_use != -1:
+            values = values[-measurements_to_use:]
 
         index_array = np.array(values)
         linear_fit = np.polyfit(index_range, index_array, 1,)
@@ -259,8 +266,10 @@ class Node:
         self,
         ip_or_hostname: str,
         password: str,
+        *,
         include_history: bool = True,
         include_trends: bool = True,
+        measurements_to_use: int = -1,
     ) -> dict:
         """Return local data from a node (via Samba)."""
         data = {}
@@ -275,6 +284,6 @@ class Node:
             if include_history:
                 data["history"] = history  # type: ignore
             if include_trends:
-                data["trends"] = _calculate_trends(history)
+                data["trends"] = _calculate_trends(history, measurements_to_use)
 
         return data

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -126,6 +126,66 @@ async def test_node_by_samba_connect_errors():
 
 
 @pytest.mark.asyncio
+async def test_node_by_samba_fewer_trend_measurements():
+    """Test getting a node's trends with a configured number of measurements."""
+    async with aiohttp.ClientSession() as websession:
+        client = Client(websession)
+
+        # Mock the tempfile that current measurements get loaded into:
+        measurements_response = load_fixture("node_measurements_samba_response.json")
+        mock_measurements_tmp_file = MagicMock()
+        mock_measurements_tmp_file.read.return_value = measurements_response.encode()
+
+        # Mock the history file that SMBConnection returns:
+        mock_history_tmp_file = MagicMock()
+        type(mock_history_tmp_file).name = PropertyMock(
+            return_value="202003_AirVisual_values.txt"
+        )
+
+        # Mock the tempfile that history data gets loaded into:
+        mock_history_file = MagicMock()
+        type(mock_history_file).filename = PropertyMock(
+            return_value="202003_AirVisual_values.txt"
+        )
+
+        # Mock opening the history file into a CSV reader:
+        mop = mock_open(read_data=load_fixture("node_history_samba_response.txt"))
+        mop.return_value.__iter__ = lambda self: self
+        mop.return_value.__next__ = lambda self: next(iter(self.readline, ""))
+
+        with patch.object(
+            tempfile,
+            "NamedTemporaryFile",
+            side_effect=[mock_measurements_tmp_file, mock_history_tmp_file],
+        ), patch("smb.SMBConnection.SMBConnection.connect"), patch(
+            "smb.SMBConnection.SMBConnection.listPath", return_value=[mock_history_file]
+        ), patch(
+            "smb.SMBConnection.SMBConnection.retrieveFile",
+        ), patch(
+            "smb.SMBConnection.SMBConnection.close"
+        ), patch(
+            "builtins.open", mop
+        ):
+            data = await client.node.from_samba(
+                TEST_NODE_IP_ADDRESS,
+                TEST_NODE_PASSWORD,
+                include_history=False,
+                measurements_to_use=3,
+            )
+
+            assert data["trends"] == {
+                "aqi_cn": "flat",
+                "aqi_us": "flat",
+                "co2": "decreasing",
+                "humidity": "decreasing",
+                "pm0_1": "flat",
+                "pm1_0": "decreasing",
+                "pm2_5": "flat",
+                "voc": "flat",
+            }
+
+
+@pytest.mark.asyncio
 async def test_node_by_samba_get_file_errors():
     """Test various errors arising while getting a file via Samba."""
     node = NodeSamba(TEST_NODE_IP_ADDRESS, TEST_NODE_PASSWORD)


### PR DESCRIPTION
**Describe what the PR does:**

By default, Node/Pro trends are calculated using all measurements from the latest history file. Although accurate, this gives a "long view" (i.e., a trend over a long amount of time). This PR implements a `measurements_to_include` parameter on `client.node.from_samba` to limit the number of measurements to use in trend calculation – fewer trends reduce accuracy, but they also timebox the data better.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
