### PR TITLE
Always include "sensor_life" key in Node/Pro data

### DIFF
--- a/pyairvisual/node.py
+++ b/pyairvisual/node.py
@@ -215,11 +215,10 @@ class NodeSamba:
             for pollutant, value in measurements
         }
 
-        if "sensor_life" in data["status"]:
-            data["status"]["sensor_life"] = {
-                _get_normalized_metric_name(pollutant): value
-                for pollutant, value in data["status"]["sensor_life"].items()
-            }
+        data["status"]["sensor_life"] = {
+            _get_normalized_metric_name(pollutant): value
+            for pollutant, value in data["status"].get("sensor_life", {}).items()
+        }
 
         return data
 

--- a/tests/fixtures/node_measurements_samba_no_sensor_life_response.json
+++ b/tests/fixtures/node_measurements_samba_no_sensor_life_response.json
@@ -1,0 +1,77 @@
+{
+    "date_and_time": {
+        "date": "2020/03/14",
+        "time": "16:52:47",
+        "timestamp": "1584204767"
+    },
+    "measurements": {
+        "co2_ppm": "442",
+        "humidity_RH": "35", "pm01_ugm3": "3",
+        "pm10_ugm3": "4",
+        "pm25_AQICN": "6",
+        "pm25_AQIUS": "17",
+        "pm25_ugm3": "4.0",
+        "temperature_C": "19.3",
+        "temperature_F": "66.8",
+        "voc_ppb": "-1"
+    },
+    "serial_number": "PV6WLM7",
+    "settings": {
+        "follow_mode": "station",
+        "followed_station": "0",
+        "is_aqi_usa": true,
+        "is_concentration_showed": true,
+        "is_indoor": true,
+        "is_lcd_on": true,
+        "is_network_time": true,
+        "is_temperature_celsius": false,
+        "language": "en-US",
+        "lcd_brightness": 80,
+        "node_name": "Office",
+        "power_saving": {
+            "2slots": [
+                {
+                    "hour_off": 9,
+                    "hour_on": 7
+                },
+                {
+                    "hour_off": 22,
+                    "hour_on": 18
+                }
+            ],
+            "mode": "yes",
+            "running_time": 99,
+            "yes": [
+                {
+                    "hour": 8,
+                    "minute": 0
+                },
+                {
+                    "hour": 21,
+                    "minute": 0
+                }
+            ]
+        },
+        "sensor_mode": {
+            "custom_mode_interval": 3,
+            "mode": 1
+        },
+        "speed_unit": "",
+        "timezone": "America/Denver",
+        "tvoc_unit": "ppb"
+    },
+    "status": {
+        "app_version": "1.1731",
+        "battery": 100,
+        "datetime": 1584204767,
+        "device_name": "AIRVISUAL-PV6WLM7",
+        "ip_address": "172.16.11.180",
+        "mac_address": "88835db41b3b",
+        "model": "20",
+        "sensor_pm25_serial": "00000005050224011145",
+        "sync_time": 250000,
+        "system_version": "KBG63F84",
+        "used_memory": 2,
+        "wifi_strength": 5
+    }
+}


### PR DESCRIPTION
**Describe what the PR does:**

This PR ensures that the Node/Pro API always returns a `sensor_life` key, even if the corresponding data is empty.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/pyairvisual/issues/60
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
