### PR TITLE
Add "measurement timestamp" for latest Node/Pro measurement

### DIFF
--- a/pyairvisual/node.py
+++ b/pyairvisual/node.py
@@ -210,6 +210,8 @@ class NodeSamba:
             # Handle a single measurement returned as a standalone dict:
             measurements = data["measurements"].items()
 
+        data["last_measurement_timestamp"] = int(data["date_and_time"]["timestamp"])
+
         data["measurements"] = {
             _get_normalized_metric_name(pollutant): value
             for pollutant, value in measurements

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -307,6 +307,7 @@ async def test_node_by_samba_list_response():
             measurements = await node.async_get_latest_measurements()
             history = await node.async_get_history()
 
+        assert measurements["last_measurement_timestamp"] == 1584204767
         assert measurements["measurements"]["co2"] == "442"
         assert measurements["measurements"]["humidity"] == "35"
         assert measurements["measurements"]["pm0_1"] == "3"

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -112,6 +112,7 @@ async def test_node_by_samba_dict_response():
             measurements = await node.async_get_latest_measurements()
             history = await node.async_get_history()
 
+        assert measurements["last_measurement_timestamp"] == 1584204767
         assert measurements["measurements"]["co2"] == "442"
         assert measurements["measurements"]["humidity"] == "35"
         assert measurements["measurements"]["pm0_1"] == "3"


### PR DESCRIPTION
**Describe what the PR does:**

This PR alters the data returned by `NodeSamba.async_get_latest_measurements` to add a local timestamp that indicates when the measurement was taken.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
