### PR TITLE
Update poetry to use core back-end

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools >= 35.0.2", "wheel >= 0.29.0", "poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+build-backend = "poetry.core.masonry.api"
 
 [tool.isort]
 combine_as_imports = true


### PR DESCRIPTION
**Describe what the PR does:**

This PR ensures that `poetry` uses the split-out `core` back-end during building.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/pyairvisual/issues/69
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
