### PR TITLE
Improve error handling for Node/Pro units

### DIFF
--- a/examples/test_node_pro.py
+++ b/examples/test_node_pro.py
@@ -15,12 +15,12 @@ async def main() -> None:
     """Create the aiohttp session and run the example."""
     logging.basicConfig(level=logging.INFO)
 
-    async with NodeSamba(NODE_PRO_IP_ADDRESS, NODE_PRO_PASSWORD) as node:
-        try:
+    try:
+        async with NodeSamba(NODE_PRO_IP_ADDRESS, NODE_PRO_PASSWORD) as node:
             _LOGGER.info(await node.async_get_latest_measurements())
             _LOGGER.info(await node.async_get_history())
-        except NodeProError as err:
-            _LOGGER.error("There was an error: %s", err)
+    except NodeProError as err:
+        _LOGGER.error(err)
 
 
 asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 [tool.poetry.dependencies]
 aiohttp = "^3.7.4"
 numpy = "^1.18.2"
-pysmb = "^1.1.28"
+pysmb = "^1.2.6"
 python = "^3.6.0"
 
 [tool.poetry.dev-dependencies]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,7 @@ aiohttp>=3.7.4
 aresponses==1.1.2
 asynctest==0.13.0
 numpy==1.18.2
-pysmb==1.1.28
+pysmb==1.2.6
 pytest-aiohttp==0.3.0
 pytest-cov==2.8.1
 pytest==5.4.1

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -53,14 +53,14 @@ async def test_node_by_samba_connect_errors():
     ):
         with pytest.raises(NodeProError) as err:
             await node.async_connect()
-        assert "The Node/Pro unit can't be connected to: " in str(err)
+        assert "The Node/Pro unit returned an error: " in str(err)
 
     with patch(
         "smb.SMBConnection.SMBConnection.connect", side_effect=smb.base.SMBTimeout,
     ):
         with pytest.raises(NodeProError) as err:
             await node.async_connect()
-        assert "Timed out while connecting to the Node/Pro unit" in str(err)
+        assert "Timed out while talking to the Node/Pro unit" in str(err)
 
     with patch(
         "smb.SMBConnection.SMBConnection.connect", side_effect=ConnectionRefusedError,
@@ -68,6 +68,13 @@ async def test_node_by_samba_connect_errors():
         with pytest.raises(NodeProError) as err:
             await node.async_connect()
         assert "Couldn't find a Node/Pro unit at IP address: 192.168.1.100" in str(err)
+
+    with patch(
+        "smb.SMBConnection.SMBConnection.connect", return_value=False,
+    ):
+        with pytest.raises(NodeProError) as err:
+            await node.async_connect()
+        assert "No data or results returned" in str(err)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

This PR makes error handling more robust:

* Interpret `False` results from Samba connections as a moment to raise an exception
* Since disconnections don't return errors easily, simplify things by only attempting to disconnect when the unit is connected
* Centralize error handling

The PR also bumps the minimum `pysmb` version to 1.2.6.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
