### PR TITLE
Reorganize error logic

### DIFF
--- a/pyairvisual/cloud_api.py
+++ b/pyairvisual/cloud_api.py
@@ -40,8 +40,8 @@ def raise_on_data_error(data: dict) -> None:
     message = data["data"]["message"]
 
     try:
-        error = next((v for k, v in ERROR_CODES.items() if k in message))
-    except StopIteration:
+        [error] = [v for k, v in ERROR_CODES.items() if k in message]
+    except ValueError:
         error = AirVisualError
     raise error(message)
 

--- a/pyairvisual/cloud_api.py
+++ b/pyairvisual/cloud_api.py
@@ -1,15 +1,49 @@
 """Define a client to interact with the AirVisual Cloud API."""
 from json.decoder import JSONDecodeError
+from typing import Dict, Type
 
 from aiohttp import ClientSession, ClientTimeout
 
 from .air_quality import AirQuality
 from .const import DEFAULT_REQUEST_TIMEOUT
-from .errors import raise_on_data_error
+from .errors import (
+    AirVisualError,
+    InvalidKeyError,
+    KeyExpiredError,
+    LimitReachedError,
+    NodeProError,
+    NoStationError,
+    NotFoundError,
+    UnauthorizedError,
+)
 from .node import NodeCloudAPI
 from .supported import Supported
 
 API_URL_BASE: str = "https://api.airvisual.com/v2"
+
+ERROR_CODES: Dict[str, Type[AirVisualError]] = {
+    "api_key_expired": KeyExpiredError,
+    "call_limit_reached": LimitReachedError,
+    "city_not_found": NotFoundError,
+    "incorrect_api_key": InvalidKeyError,
+    "no_nearest_station": NoStationError,
+    "node not found": NodeProError,
+    "permission_denied": UnauthorizedError,
+}
+
+
+def raise_on_data_error(data: dict) -> None:
+    """Raise an error if the data payload suggests there is one."""
+    if "data" not in data or data.get("status") == "success":
+        return
+
+    message = data["data"]["message"]
+
+    try:
+        error = next((v for k, v in ERROR_CODES.items() if k in message))
+    except StopIteration:
+        error = AirVisualError
+    raise error(message)
 
 
 class CloudAPI:  # pylint: disable=too-few-public-methods

--- a/pyairvisual/errors.py
+++ b/pyairvisual/errors.py
@@ -1,5 +1,4 @@
 """Define package errors."""
-from typing import Dict, Type
 
 
 class AirVisualError(Exception):
@@ -54,28 +53,3 @@ class UnauthorizedError(AirVisualError):
     """Define an error related to unauthorized requests."""
 
     pass
-
-
-ERROR_CODES: Dict[str, Type[AirVisualError]] = {
-    "api_key_expired": KeyExpiredError,
-    "call_limit_reached": LimitReachedError,
-    "city_not_found": NotFoundError,
-    "incorrect_api_key": InvalidKeyError,
-    "no_nearest_station": NoStationError,
-    "node not found": NodeProError,
-    "permission_denied": UnauthorizedError,
-}
-
-
-def raise_on_data_error(data: dict) -> None:
-    """Raise an error if the data payload suggests there is one."""
-    if "data" not in data or data.get("status") == "success":
-        return
-
-    message = data["data"]["message"]
-
-    try:
-        error = next((v for k, v in ERROR_CODES.items() if k in message))
-    except StopIteration:
-        error = AirVisualError
-    raise error(message)

--- a/pyairvisual/node.py
+++ b/pyairvisual/node.py
@@ -90,7 +90,11 @@ def _calculate_trends(history: List[OrderedDict], measurements_to_use: int) -> d
             values = values[-measurements_to_use:]
 
         index_array = np.array(values)
-        linear_fit = np.polyfit(index_range, index_array, 1,)
+        linear_fit = np.polyfit(
+            index_range,
+            index_array,
+            1,
+        )
         slope = round(linear_fit[0], 2)
 
         metric = _get_normalized_metric_name(attribute)
@@ -168,7 +172,9 @@ class NodeSamba:
         return result
 
     async def _async_get_file(
-        self, filepath: str, file_obj: tempfile.NamedTemporaryFile,  # type: ignore
+        self,
+        filepath: str,
+        file_obj: tempfile.NamedTemporaryFile,  # type: ignore
     ) -> None:
         """Save a file to a tempfile object."""
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -49,28 +49,32 @@ async def test_node_by_samba_connect_errors():
     node = NodeSamba(TEST_NODE_IP_ADDRESS, TEST_NODE_PASSWORD)
 
     with patch(
-        "smb.SMBConnection.SMBConnection.connect", side_effect=smb.base.NotReadyError,
+        "smb.SMBConnection.SMBConnection.connect",
+        side_effect=smb.base.NotReadyError,
     ):
         with pytest.raises(NodeProError) as err:
             await node.async_connect()
         assert "The Node/Pro unit returned an error: " in str(err)
 
     with patch(
-        "smb.SMBConnection.SMBConnection.connect", side_effect=smb.base.SMBTimeout,
+        "smb.SMBConnection.SMBConnection.connect",
+        side_effect=smb.base.SMBTimeout,
     ):
         with pytest.raises(NodeProError) as err:
             await node.async_connect()
         assert "Timed out while talking to the Node/Pro unit" in str(err)
 
     with patch(
-        "smb.SMBConnection.SMBConnection.connect", side_effect=ConnectionRefusedError,
+        "smb.SMBConnection.SMBConnection.connect",
+        side_effect=ConnectionRefusedError,
     ):
         with pytest.raises(NodeProError) as err:
             await node.async_connect()
         assert "Couldn't find a Node/Pro unit at IP address: 192.168.1.100" in str(err)
 
     with patch(
-        "smb.SMBConnection.SMBConnection.connect", return_value=False,
+        "smb.SMBConnection.SMBConnection.connect",
+        return_value=False,
     ):
         with pytest.raises(NodeProError) as err:
             await node.async_connect()
@@ -212,7 +216,8 @@ async def test_node_by_samba_get_file_errors():
             _ = await node.async_get_latest_measurements()
 
     with patch("smb.SMBConnection.SMBConnection.connect"), patch(
-        "smb.SMBConnection.SMBConnection.retrieveFile", side_effect=smb.base.SMBTimeout,
+        "smb.SMBConnection.SMBConnection.retrieveFile",
+        side_effect=smb.base.SMBTimeout,
     ):
         with pytest.raises(NodeProError):
             await node.async_connect()
@@ -249,7 +254,8 @@ async def test_node_by_samba_history_errors():
             _ = await node.async_get_history()
 
     with patch("smb.SMBConnection.SMBConnection.connect"), patch(
-        "smb.SMBConnection.SMBConnection.listPath", side_effect=smb.base.SMBTimeout,
+        "smb.SMBConnection.SMBConnection.listPath",
+        side_effect=smb.base.SMBTimeout,
     ):
         with pytest.raises(NodeProError):
             await node.async_connect()


### PR DESCRIPTION
**Describe what the PR does:**

This PR centralizes Cloud API-specific error login in that module (vs. keeping it in a strange location within a constants file).

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
