### PR TITLE
Create CloudAPIError

### DIFF
--- a/pyairvisual/errors.py
+++ b/pyairvisual/errors.py
@@ -7,26 +7,8 @@ class AirVisualError(Exception):
     pass
 
 
-class InvalidKeyError(AirVisualError):
-    """Define an error when the API key is invalid."""
-
-    pass
-
-
-class KeyExpiredError(AirVisualError):
-    """Define an error when the API key has expired."""
-
-    pass
-
-
-class LimitReachedError(AirVisualError):
-    """Define an error when the API limit has been reached."""
-
-    pass
-
-
-class NoStationError(AirVisualError):
-    """Define an error when there's no station for the data requested."""
+class CloudAPIError(AirVisualError):
+    """Define an error related to the Cloud API."""
 
     pass
 
@@ -37,19 +19,43 @@ class NodeProError(AirVisualError):
     pass
 
 
-class NotFoundError(AirVisualError):
+class InvalidKeyError(CloudAPIError):
+    """Define an error when the API key is invalid."""
+
+    pass
+
+
+class KeyExpiredError(CloudAPIError):
+    """Define an error when the API key has expired."""
+
+    pass
+
+
+class LimitReachedError(CloudAPIError):
+    """Define an error when the API limit has been reached."""
+
+    pass
+
+
+class NoStationError(CloudAPIError):
+    """Define an error when there's no station for the data requested."""
+
+    pass
+
+
+class NotFoundError(CloudAPIError):
     """Define an error for when a location (city or node) cannot be found."""
 
     pass
 
 
-class RequestError(AirVisualError):
+class RequestError(CloudAPIError):
     """Define an error related to invalid requests."""
 
     pass
 
 
-class UnauthorizedError(AirVisualError):
+class UnauthorizedError(CloudAPIError):
     """Define an error related to unauthorized requests."""
 
     pass


### PR DESCRIPTION
**Describe what the PR does:**

This PR introduces `CloudAPIError`. This error is not necessarily intended to be used directly; rather, it allows viewers of the code base to demarcate to which "venue" (Cloud API or Node/Pro) an error belongs.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
