### PR TITLE
Bump numpy to 1.22.0 minimum

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 aiohttp = ">=3.8.0"
-numpy = "^1.21.2"
+numpy = ">=1.22.0"
 pysmb = "^1.2.6"
 python = ">=3.7.0,<3.11"
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,7 @@
 aiohttp>=3.8.0
 aresponses==1.1.2
 asynctest==0.13.0
-numpy==1.21.2
+numpy==1.22.0
 pysmb==1.2.6
 pytest-aiohttp==0.3.0
 pytest-cov==2.8.1


### PR DESCRIPTION
**Describe what the PR does:**

This PR bumps `numpy` to a minimum of 1.22.0.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
