### PR TITLE
Ensure `node` grabs the correct history file from a Node unit

### DIFF
--- a/pyairvisual/node.py
+++ b/pyairvisual/node.py
@@ -260,6 +260,7 @@ class NodeSamba:
             )
 
         history_files = await self._async_execute_samba_command(search_history)
+        history_files.sort(key=lambda file: file.filename)
 
         if not history_files:
             raise NodeProError(


### PR DESCRIPTION
**Describe what the PR does:**

sort history files before assuming -1 index refers to the most recent history file

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
