### PR TITLE
Ensure "Forbidden" response message is caught as an appropriate error

### DIFF
--- a/pyairvisual/cloud_api.py
+++ b/pyairvisual/cloud_api.py
@@ -70,6 +70,7 @@ ERROR_CODES: dict[str, type[AirVisualError]] = {
     "call_limit_reached": LimitReachedError,
     "city_not_found": NotFoundError,
     "feature_not_available": UnauthorizedError,
+    "forbidden": UnauthorizedError,
     "incorrect_api_key": InvalidKeyError,
     "no_nearest_station": NoStationError,
     "node not found": NotFoundError,
@@ -91,7 +92,9 @@ def raise_on_data_error(data: dict[str, Any]) -> None:
         return
 
     try:
-        [error] = [v for k, v in ERROR_CODES.items() if k in data["data"]["message"]]
+        [error] = [
+            v for k, v in ERROR_CODES.items() if k in data["data"]["message"].lower()
+        ]
     except ValueError:
         error = AirVisualError
     raise error(data)

--- a/tests/fixtures/error_forbidden_response.json
+++ b/tests/fixtures/error_forbidden_response.json
@@ -1,0 +1,6 @@
+{
+  "status": "fail",
+  "data": {
+    "message": "Forbidden"
+  }
+}


### PR DESCRIPTION
**Describe what the PR does:**

Via https://github.com/home-assistant/core/issues/81542, a user retrieved this response:

```json
{
  "status": "fail",
  "data": {
    "message": "Forbidden"
  }
}
```

...which we currently don't have a mapping for; this causes it to return a too-generic exception. This PR ensures this response returns an `UnauthorizedError`.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
