### PR TITLE
Capture "Payment Required" errors

### DIFF
--- a/pyairvisual/cloud_api.py
+++ b/pyairvisual/cloud_api.py
@@ -74,6 +74,7 @@ ERROR_CODES: dict[str, type[AirVisualError]] = {
     "incorrect_api_key": InvalidKeyError,
     "no_nearest_station": NoStationError,
     "node not found": NotFoundError,
+    "payment required": InvalidKeyError,
     "permission_denied": UnauthorizedError,
     "too_many_requests": LimitReachedError,
 }

--- a/tests/cloud_api/conftest.py
+++ b/tests/cloud_api/conftest.py
@@ -54,6 +54,16 @@ def error_city_not_found_response_fixture() -> str:
     return load_fixture("error_city_not_found_response.json")
 
 
+@pytest.fixture(name="error_forbidden_response", scope="session")
+def error_forbidden_response_fixture() -> str:
+    """Define a fixture for error response data (forbidden).
+
+    Returns:
+        An API response payload.
+    """
+    return load_fixture("error_forbidden_response.json")
+
+
 @pytest.fixture(name="error_generic_response", scope="session")
 def error_generic_response_fixture() -> str:
     """Define a fixture for error response data (generic).
@@ -112,6 +122,16 @@ def error_node_not_found_response_fixture() -> str:
         An API response payload.
     """
     return '"node not found"'
+
+
+@pytest.fixture(name="error_payment_required_response", scope="session")
+def error_payment_required_response_fixture() -> str:
+    """Define a fixture for error response data (payment required).
+
+    Returns:
+        An API response payload.
+    """
+    return load_fixture("error_payment_required_response.json")
 
 
 @pytest.fixture(name="error_permission_denied_response", scope="session")

--- a/tests/cloud_api/test_errors.py
+++ b/tests/cloud_api/test_errors.py
@@ -48,12 +48,14 @@ async def test_invalid_json_response(aresponses: ResponsesMockServer) -> None:
     "response_text_fixture,status_code,exception",
     [
         ("error_city_not_found_response", 400, NotFoundError),
+        ("error_forbidden_response", 403, UnauthorizedError),
         ("error_generic_response", 404, AirVisualError),
         ("error_incorrect_api_key_response", 401, InvalidKeyError),
         ("error_key_expired_response", 401, KeyExpiredError),
         ("error_limit_reached_response", 429, LimitReachedError),
         ("error_no_nearest_station_response", 404, NoStationError),
         ("error_node_not_found_response", 404, NotFoundError),
+        ("error_payment_required_response", 403, InvalidKeyError),
         ("error_permission_denied_response", 403, UnauthorizedError),
     ],
 )

--- a/tests/fixtures/error_payment_required_response.json
+++ b/tests/fixtures/error_payment_required_response.json
@@ -1,0 +1,6 @@
+{
+  "status": "fail",
+  "data": {
+    "message": "Payment Required"
+  }
+}


### PR DESCRIPTION
**Describe what the PR does:**

I recently saw this error for an about-to-expire API key:

![CleanShot 2022-11-05 at 10 11 27](https://user-images.githubusercontent.com/47216/200129354-26797148-0d76-4d41-8472-495a61a9e277.png)

This PR ensures that when this error is seen, an `InvalidKeyError` is raised.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
