### PR TITLE
Reduce log level for Pro connection/disconnection scenarios

### DIFF
--- a/pyairvisual/node.py
+++ b/pyairvisual/node.py
@@ -373,7 +373,7 @@ class NodeSamba:
                 is incorrect.
         """
         if self._connected:
-            LOGGER.warning("Already connected!")
+            LOGGER.debug("Already connected!")
             return
 
         result = await self._execute_samba_operation(
@@ -388,7 +388,7 @@ class NodeSamba:
     async def async_disconnect(self) -> None:
         """Disconnect from the Node."""
         if not self._connected:
-            LOGGER.warning("Already disconnected!")
+            LOGGER.debug("Already disconnected!")
             return
 
         await self._execute_samba_operation(self._conn.close)

--- a/tests/node/test_requests_responses.py
+++ b/tests/node/test_requests_responses.py
@@ -1,5 +1,6 @@
 """Define tests for Node errors."""
 # pylint: disable=unused-argument
+import logging
 from collections.abc import Generator
 from unittest.mock import Mock
 
@@ -19,6 +20,8 @@ async def test_duplicate_connection(
         caplog: A mocked logging facility.
         setup_samba_connection: A mocked Samba connection.
     """
+    caplog.set_level(logging.DEBUG)
+
     node = NodeSamba(TEST_NODE_IP_ADDRESS, TEST_NODE_PASSWORD)
     await node.async_connect()
     await node.async_connect()
@@ -37,6 +40,8 @@ async def test_duplicate_disconnection(
         caplog: A mocked logging facility.
         setup_samba_connection: A mocked Samba connection.
     """
+    caplog.set_level(logging.DEBUG)
+
     node = NodeSamba(TEST_NODE_IP_ADDRESS, TEST_NODE_PASSWORD)
     await node.async_connect()
     await node.async_disconnect()


### PR DESCRIPTION
**Describe what the PR does:**

We shouldn't warn if a redundant connection/disconnection is performed. This PR reduces the log level to `DEBUG`.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
