### PR TITLE
Fix history during file rotation

### DIFF
--- a/pyairvisual/node.py
+++ b/pyairvisual/node.py
@@ -426,13 +426,17 @@ class NodeSamba:
 
         data: dict[str, Any] = {}
 
-        for index in range(len(history_files)):
-            tmp_file = tempfile.NamedTemporaryFile()  # pylint: disable=consider-using-with
+        for history_file in history_files:
+            tmp_file = (
+                tempfile.NamedTemporaryFile()  # pylint: disable=consider-using-with
+            )
             await self._async_store_filepath_in_tempfile(
-                f"/{history_files[index].filename}", tmp_file
+                f"/{history_file.filename}", tmp_file
             )
             tmp_file.seek(0)
-            data["measurements"] = await self._async_retrieve_data_from_tempfile(tmp_file)
+            data["measurements"] = await self._async_retrieve_data_from_tempfile(
+                tmp_file
+            )
             tmp_file.close()
 
             if include_trends:
@@ -440,7 +444,7 @@ class NodeSamba:
                     data["measurements"], measurements_to_use
                 )
 
-            if not data["measurements"]:
+            if data["measurements"]:
                 break
 
         return data

--- a/pyairvisual/node.py
+++ b/pyairvisual/node.py
@@ -417,7 +417,7 @@ class NodeSamba:
             NodeProError: Raised when no history files are found.
         """
         history_files = await self._async_get_history_files()
-        history_files.sort(key=lambda file: file.filename)
+        history_files.sort(key=lambda file: file.filename, reverse=True)
 
         if not history_files:
             raise NodeProError(
@@ -426,18 +426,22 @@ class NodeSamba:
 
         data: dict[str, Any] = {}
 
-        tmp_file = tempfile.NamedTemporaryFile()  # pylint: disable=consider-using-with
-        await self._async_store_filepath_in_tempfile(
-            f"/{history_files[-1].filename}", tmp_file
-        )
-        tmp_file.seek(0)
-        data["measurements"] = await self._async_retrieve_data_from_tempfile(tmp_file)
-        tmp_file.close()
-
-        if include_trends:
-            data["trends"] = _calculate_trends(
-                data["measurements"], measurements_to_use
+        for index in range(len(history_files)):
+            tmp_file = tempfile.NamedTemporaryFile()  # pylint: disable=consider-using-with
+            await self._async_store_filepath_in_tempfile(
+                f"/{history_files[index].filename}", tmp_file
             )
+            tmp_file.seek(0)
+            data["measurements"] = await self._async_retrieve_data_from_tempfile(tmp_file)
+            tmp_file.close()
+
+            if include_trends:
+                data["trends"] = _calculate_trends(
+                    data["measurements"], measurements_to_use
+                )
+
+            if not data["measurements"]:
+                break
 
         return data
 


### PR DESCRIPTION
**Describe what the PR does:**

When files are rotated on the local nodes the file gets replaced but data isn't put into it immediately. This creates a five minute window where the get history function returns empty measurements.

Here's what it looks like when graphing the history data without the fix-

<img width="550" alt="Screenshot 2023-08-05 at 6 02 32 PM" src="https://github.com/bachya/pyairvisual/assets/121709/3eca7dff-6e72-4ade-9f20-eb376498cbfe">


**Checklist:**

- N/A Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` with any new documentation.


