### PR TITLE
Fix issue with incorrect Python version spec

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1602,5 +1602,5 @@ multidict = ">=4.0"
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.10,<=3.12"
-content-hash = "c4ed50897f21cc8f7df39e2bc87b64b092b695143341d1b6f29598f3ff93528d"
+python-versions = "^3.10"
+content-hash = "91b998cfe8392e16c7774b1a26bcf8744ff70aabef3ca91a2e3898addb08102e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ frozenlist = "^1.4.0"
 numpy = ">=1.26.2"
 pygments = ">=2.15.0"
 pysmb = "^1.2.6"
-python = ">=3.10,<=3.12"
+python = "^3.10"
 yarl = ">=1.9.2"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
**Describe what the PR does:**

The current version spec was too restrictive and disallowed patch versions of 3.12.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
